### PR TITLE
Support outputting .aab files

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -505,6 +505,17 @@ func (builder Model) CollectProjectOutputs(configuration, platform string, start
 			} else {
 				log.Debugf("No valid apk path found.")
 			}
+
+			if aabPth, err := exportAab(projectConfig.OutputDir, packageName, startTime, endTime); err != nil {
+				return ProjectOutputMap{}, fmt.Errorf("could not export apk. Error: %v", err)
+			} else if aabPth != "" {
+				projectOutputs.Outputs = append(projectOutputs.Outputs, OutputModel{
+					Pth:        aabPth,
+					OutputType: constants.OutputTypeAAB,
+				})
+			} else {
+				log.Debugf("No valid aab path found.")
+			}
 		}
 
 		if len(projectOutputs.Outputs) > 0 {

--- a/builder/export.go
+++ b/builder/export.go
@@ -139,6 +139,15 @@ func exportApk(outputDir, assemblyName string, startTime, endTime time.Time) (st
 	)
 }
 
+func exportAab(outputDir, assemblyName string, startTime, endTime time.Time) (string, error) {
+	return findArtifact(outputDir, startTime, endTime, false,
+		fmt.Sprintf(`(?i).*%s.*signed.*\.aab$`, assemblyName),
+		fmt.Sprintf(`(?i).*%s.*\.aab$`, assemblyName),
+		`(?i).*signed.*\.aab$`,
+		`(?i).*\.aab$`,
+	)
+}
+
 func exportIpa(outputDir, assemblyName string, startTime, endTime time.Time) (string, error) {
 	return findArtifact(outputDir, startTime, endTime, true,
 		fmt.Sprintf(`(?i).*%s.*\.ipa$`, assemblyName),

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -128,6 +128,8 @@ const (
 	OutputTypeAPP OutputType = "app"
 	// OutputTypeDLL ...
 	OutputTypeDLL OutputType = "dll"
+	// OutputTypeAAB ...
+	OutputTypeAAB OutputType = "aab"
 )
 
 // ParseOutputType ...
@@ -147,6 +149,8 @@ func ParseOutputType(outputType string) (OutputType, error) {
 		return OutputTypeAPP, nil
 	case "dll":
 		return OutputTypeDLL, nil
+	case "aab":
+		return OutputTypeAAB, nil
 	default:
 		return OutputTypeUnknown, fmt.Errorf("invalid output type: %s", outputType)
 	}


### PR DESCRIPTION
This adds another file type that can be deployed in the Xamarin archive step, .aab files

This is needed for https://github.com/bitrise-steplib/steps-xamarin-archive/issues/35