### PR TITLE
STEP-1304: Support AAB export

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -505,6 +505,17 @@ func (builder Model) CollectProjectOutputs(configuration, platform string, start
 			} else {
 				log.Debugf("No valid apk path found.")
 			}
+
+			if aabPth, err := exportAab(projectConfig.OutputDir, packageName, startTime, endTime); err != nil {
+				return ProjectOutputMap{}, fmt.Errorf("could not export aab. Error: %v", err)
+			} else if aabPth != "" {
+				projectOutputs.Outputs = append(projectOutputs.Outputs, OutputModel{
+					Pth:        aabPth,
+					OutputType: constants.OutputTypeAAB,
+				})
+			} else {
+				log.Debugf("No valid aab path found.")
+			}
 		}
 
 		if len(projectOutputs.Outputs) > 0 {

--- a/builder/export.go
+++ b/builder/export.go
@@ -139,6 +139,15 @@ func exportApk(outputDir, assemblyName string, startTime, endTime time.Time) (st
 	)
 }
 
+func exportAab(outputDir, assemblyName string, startTime, endTime time.Time) (string, error) {
+	return findArtifact(outputDir, startTime, endTime, false,
+		fmt.Sprintf(`(?i).*%s.*signed.*\.aab$`, assemblyName),
+		fmt.Sprintf(`(?i).*%s.*\.aab$`, assemblyName),
+		`(?i).*signed.*\.aab$`,
+		`(?i).*\.aab$`,
+	)
+}
+
 func exportIpa(outputDir, assemblyName string, startTime, endTime time.Time) (string, error) {
 	return findArtifact(outputDir, startTime, endTime, true,
 		fmt.Sprintf(`(?i).*%s.*\.ipa$`, assemblyName),

--- a/builder/export_test.go
+++ b/builder/export_test.go
@@ -202,11 +202,7 @@ func Test_exportApk(t *testing.T) {
 	startTime := time.Now()
 	time.Sleep(3 * time.Second)
 
-	for _, pth := range []string{
-		"file-signed.apk",
-		"file.apk",
-		"artifact.apk",
-	} {
+	for _, pth := range []string{"file-signed.apk", "file.apk", "artifact.apk"} {
 		createTestFile(t, tmpDir, pth)
 		time.Sleep(3 * time.Second)
 	}
@@ -224,18 +220,58 @@ func Test_exportApk(t *testing.T) {
 		require.Equal(t, filepath.Join(tmpDir, "artifact.apk"), pth)
 	}
 
-	t.Log("it prefres signed apk")
+	t.Log("it prefers signed apk")
 	{
 		pth, err := exportApk(tmpDir, "file", startTime, endTime)
 		require.NoError(t, err)
 		require.Equal(t, filepath.Join(tmpDir, "file-signed.apk"), pth)
 	}
 
-	t.Log("it returns latest signed apk if artificat name does not match")
+	t.Log("it returns latest signed apk if artifact name does not match")
 	{
 		pth, err := exportApk(tmpDir, "does not match", startTime, endTime)
 		require.NoError(t, err)
 		require.Equal(t, filepath.Join(tmpDir, "file-signed.apk"), pth)
+	}
+}
+
+func Test_exportAab(t *testing.T) {
+	tmpDir, err := pathutil.NormalizedOSTempDirPath("file_infos_test")
+	require.NoError(t, err)
+
+	startTime := time.Now()
+	time.Sleep(3 * time.Second)
+
+	for _, pth := range []string{"file-signed.aab", "file.aab", "artifact.aab"} {
+		createTestFile(t, tmpDir, pth)
+		time.Sleep(3 * time.Second)
+	}
+
+	time.Sleep(3 * time.Second)
+	endTime := time.Now()
+	time.Sleep(3 * time.Second)
+
+	createTestFile(t, tmpDir, "artifact-signed.aab")
+
+	t.Log("time window test")
+	{
+		pth, err := exportAab(tmpDir, "artifact", startTime, endTime)
+		require.NoError(t, err)
+		require.Equal(t, filepath.Join(tmpDir, "artifact.aab"), pth)
+	}
+
+	t.Log("it prefers signed aab")
+	{
+		pth, err := exportAab(tmpDir, "file", startTime, endTime)
+		require.NoError(t, err)
+		require.Equal(t, filepath.Join(tmpDir, "file-signed.aab"), pth)
+	}
+
+	t.Log("it returns latest signed aab if artifact name does not match")
+	{
+		pth, err := exportAab(tmpDir, "does not match", startTime, endTime)
+		require.NoError(t, err)
+		require.Equal(t, filepath.Join(tmpDir, "file-signed.aab"), pth)
 	}
 }
 

--- a/builder/utility.go
+++ b/builder/utility.go
@@ -29,7 +29,7 @@ func validateSolutionPth(pth string) error {
 func validateSolutionConfig(solution solution.Model, configuration, platform string) error {
 	config := utility.ToConfig(configuration, platform)
 	if _, ok := solution.ConfigMap[config]; !ok {
-		return fmt.Errorf("invalid solution config, available: %v", solution.ConfigList())
+		return fmt.Errorf("invalid solution config: %s, available: %v", config, solution.ConfigList())
 	}
 	return nil
 }

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -116,6 +116,8 @@ const (
 	OutputTypeUnknown OutputType = "unknown"
 	// OutputTypeAPK ...
 	OutputTypeAPK OutputType = "apk"
+	// OutputTypeAAB ...
+	OutputTypeAAB OutputType = "aab"
 	// OutputTypeXCArchive ...
 	OutputTypeXCArchive OutputType = "xcarchive"
 	// OutputTypeIPA ...
@@ -135,6 +137,8 @@ func ParseOutputType(outputType string) (OutputType, error) {
 	switch outputType {
 	case "apk":
 		return OutputTypeAPK, nil
+	case "aab":
+		return OutputTypeAAB, nil
 	case "xcarchive":
 		return OutputTypeXCArchive, nil
 	case "ipa":

--- a/constants/constants_test.go
+++ b/constants/constants_test.go
@@ -155,6 +155,13 @@ func TestParseOutputType(t *testing.T) {
 		require.Equal(t, OutputTypeAPK, outputType)
 	}
 
+	t.Log("it parses aab")
+	{
+		outputType, err := ParseOutputType("aab")
+		require.NoError(t, err)
+		require.Equal(t, OutputTypeAAB, outputType)
+	}
+
 	t.Log("it parses xcarchive")
 	{
 		outputType, err := ParseOutputType("xcarchive")


### PR DESCRIPTION
## Context
* Google Play will start requiring new apps to be published with the Android App Bundle starting August 2021.
* The current Xamarin Archive step cannot export an AAB even if it's set as the output in your project.
* This is because the `go-xamarin` library doesn't export an AAB (as it does with APK).

## Changes
* Export AAB if available (similarly to APK export).

## Next steps
* Modify the Xamarin Archive step to expose the exported AAB path as an output.